### PR TITLE
一点脚本的优化和遇到的bug修复

### DIFF
--- a/file_add.list
+++ b/file_add.list
@@ -1,10 +1,12 @@
 usr/bin/pv
 usr/sbin/debootstrap
 lib/mips64el-linux-gnuabi64/libtinfo.so.6*
+lib/mips64el-linux-gnuabi64/libtinfo.so.5*
 lib/mips64el-linux-gnuabi64/libfdisk.so.1*
 lib/mips64el-linux-gnuabi64/libsmartcols.so.1*
 sbin/cfdisk
 lib/mips64el-linux-gnuabi64/libncursesw.so.6*
+lib/mips64el-linux-gnuabi64/libncursesw.so.5*
 usr/share/terminfo/x/xterm-utf8
 usr/share/terminfo/x/xterm-color
 sbin/hdparm
@@ -16,3 +18,11 @@ sbin/fsck.msdos
 sbin/fsck.vfat
 sbin/mke2fs
 sbin/mkfs.ext*
+lib/mips64el-linux-gnuabi64/libext2fs.so*
+lib/mips64el-linux-gnuabi64/libcom_err.so*
+lib/mips64el-linux-gnuabi64/libblkid.so*
+lib/mips64el-linux-gnuabi64/libuuid.so*
+lib/mips64el-linux-gnuabi64/libe2p.so*
+lib/mips64el-linux-gnuabi64/libdl.so*
+lib/mips64el-linux-gnuabi64/libc.so*
+lib/mips64el-linux-gnuabi64/libpthread.so*


### PR DESCRIPTION
build.sh: 添加构建支持选择内核版本用于chroot中构建;
添加检查pv命令并安装。
file_add.list：修复在旧版系统上so版本较老不能被拷贝的bug；
修复旧版系统上mkfs.ext*命令依赖的库未被拷贝造成格式化失败的bug